### PR TITLE
fix nvidia driver detection

### DIFF
--- a/ld.so.conf
+++ b/ld.so.conf
@@ -1,1 +1,4 @@
+include /run/flatpak/ld.so.conf.d/app-*-org.freedesktop.Platform.GL32.*.conf
 /app/lib32
+/app/lib/i386-linux-gnu
+/lib64

--- a/net.pcsx2.PCSX2.json
+++ b/net.pcsx2.PCSX2.json
@@ -26,7 +26,8 @@
         },
         "org.freedesktop.Platform.GL32": {
             "directory": "lib/i386-linux-gnu/GL",
-            "version": "19.08",
+            "version": "1.4",
+            "versions": "19.08;1.4",
             "subdirectories": true,
             "no-autodownload": true,
             "autodelete": false,
@@ -56,7 +57,8 @@
           "buildsystem": "simple",
           "build-commands": [
               "mkdir -p /app/lib/i386-linux-gnu",
-              "mkdir -p  /app/lib/debug/lib/i386-linux-gnu",
+              "mkdir -p /app/lib/debug/lib/i386-linux-gnu",
+              "mkdir -p /app/lib/i386-linux-gnu/GL",
               "install -Dm644 -t /app/etc ld.so.conf"
           ],
           "sources": [


### PR DESCRIPTION
I copied over the stuff from the steam flatpak. I think the problem is that the runtime version of the nvidia driver is 1.4 and this version was missing from the GL32 driver list?

fixes https://github.com/flathub/net.pcsx2.PCSX2/issues/27