### PR TITLE
Update to 21.08 runtime and improve build configuration

### DIFF
--- a/net.pcsx2.PCSX2.json
+++ b/net.pcsx2.PCSX2.json
@@ -96,7 +96,7 @@
       "sources": [
         {
           "type": "git",
-          "url": "https://gitlab.com/soundtouch/soundtouch.git",
+          "url": "https://codeberg.org/soundtouch/soundtouch.git",
           "tag": "2.3.1",
           "commit": "e1f315f5358d9db5cee35a7a2886425489fcefe8",
           "x-checker-data": {
@@ -180,7 +180,13 @@
           "type": "git",
           "url": "https://github.com/PCSX2/pcsx2.git",
           "disable-shallow-clone": true,
-          "commit": "9abaa1adf684645d4b0a4cbcfc9959031d0cc087"
+          "tag": "v1.7.2035",
+          "commit": "cf64a2bc8e43a271f386b19778780cf210b2f8fc",
+          "x-checker-data": {
+              "type": "git",
+              "tag-pattern": "^v([\\d.]+)$",
+              "is-main-source": true
+          }
         },
         {
           "type": "file",

--- a/net.pcsx2.PCSX2.json
+++ b/net.pcsx2.PCSX2.json
@@ -63,9 +63,14 @@
       },
       "sources": [
         {
-          "type": "archive",
-          "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.4/wxWidgets-3.0.4.tar.bz2",
-          "sha256": "96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0"
+          "type": "git",
+          "url": "https://github.com/wxWidgets/wxWidgets.git",
+          "tag": "v3.1.5",
+          "commit": "9c0a8be1dc32063d91ed1901fd5fcd54f4f955a1",
+          "x-checker-data": {
+              "type": "git",
+              "tag-pattern": "^v([\\d.]+)$"
+          }
         }
       ],
       "modules": [
@@ -85,8 +90,12 @@
         {
           "type": "git",
           "url": "https://pagure.io/libaio.git",
-          "tag": "libaio-0.3.111",
-          "commit": "f66be22ab0a59a39858900ab72a8c6a6e8b0b7ec"
+          "tag": "libaio-0.3.112",
+          "commit": "d025927efa75a0d1b46ca3a5ef331caa2f46ee0e",
+          "x-checker-data": {
+              "type": "git",
+              "tag-pattern": "^libaio-([\\d.]+)$"
+          }
         }
       ]
     },
@@ -102,9 +111,14 @@
       ],
       "sources": [
         {
-          "type": "archive",
-          "url": "http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz",
-          "sha256": "f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513"
+          "type": "git",
+          "url": "https://github.com/PortAudio/portaudio.git",
+          "tag": "v19.7.0",
+          "commit": "147dd722548358763a8b649b3e4b41dfffbcfbb6",
+          "x-checker-data": {
+              "type": "git",
+              "tag-pattern": "^v([\\d.]+)$"
+          }
         }
       ]
     },
@@ -115,9 +129,14 @@
       ],
       "sources": [
         {
-          "type": "archive",
-          "url": "https://gitlab.com/soundtouch/soundtouch/-/archive/2.1.1/soundtouch-2.1.1.tar.gz",
-          "sha256": "09311b159e15b2f5ceec953ad711922b466642a3000449f17de1874ce7a3ac8a"
+          "type": "git",
+          "url": "https://gitlab.com/soundtouch/soundtouch.git",
+          "tag": "2.3.1",
+          "commit": "e1f315f5358d9db5cee35a7a2886425489fcefe8",
+          "x-checker-data": {
+              "type": "git",
+              "tag-pattern": "^([\\d.]+)$"
+          }
         }
       ],
       "cleanup": [
@@ -155,9 +174,14 @@
       ],
       "sources": [
         {
-          "type": "archive",
-          "url": "http://www.tcpdump.org/release/libpcap-1.10.0.tar.gz",
-          "md5": "8c12dc19dd7e0d02d2bb6596eb5a71c7"
+          "type": "git",
+          "url": "https://github.com/the-tcpdump-group/libpcap.git",
+          "tag": "libpcap-1.10.1",
+          "commit": "c7642e2cc0c5bd65754685b160d25dc23c76c6bd",
+          "x-checker-data": {
+              "type": "git",
+              "tag-pattern": "^libpcap-([\\d.]+)$"
+          }
         }
       ]
     },

--- a/net.pcsx2.PCSX2.json
+++ b/net.pcsx2.PCSX2.json
@@ -2,7 +2,7 @@
   "app-id": "net.pcsx2.PCSX2",
   "runtime": "org.freedesktop.Platform",
   "sdk": "org.freedesktop.Sdk",
-  "runtime-version": "20.08",
+  "runtime-version": "21.08",
   "command": "PCSX2",
   "rename-desktop-file": "PCSX2.desktop",
   "rename-icon": "PCSX2",
@@ -11,56 +11,20 @@
     "--share=ipc",
     "--socket=x11",
     "--socket=pulseaudio",
-    "--filesystem=host:ro",
-    "--allow=multiarch"
+    "--filesystem=host:ro"
   ],
-  "add-extensions": {
-    "org.freedesktop.Platform.GL": {
-      "directory": "lib/GL",
-      "version": "1.4",
-      "versions": "20.08;1.4",
-      "subdirectories": true,
-      "no-autodownload": true,
-      "autodelete": false,
-      "add-ld-path": "lib",
-      "merge-dirs": "vulkan/icd.d;glvnd/egl_vendor.d",
-      "download-if": "active-gl-driver",
-      "enable-if": "active-gl-driver"
-    }
-  },
-  "cleanup-commands": [
-    "mkdir -p /app/lib/GL"
-  ],
-  "sdk-extensions": [],
-  "build-options": {},
   "modules": [
     {
       "name": "wxWidgets",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+          "-DCMAKE_BUILD_TYPE=Release"
+      ],
       "cleanup": [
         "/bin",
         "/include",
-        "/share/bakefile",
-        "/share/aclocal",
-        "/lib32/wx/include"
+        "/lib/wx/include"
       ],
-      "config-opts": [
-        "--with-opengl",
-        "--with-libjpeg",
-        "--with-libpng",
-        "--with-zlib",
-        "--disable-sdltest",
-        "--enable-unicode",
-        "--enable-display",
-        "--enable-propgrid",
-        "--disable-webkit",
-        "--disable-webview",
-        "--disable-webviewwebkit",
-        "--with-expat=builtin",
-        "--with-libiconv=/usr"
-      ],
-      "build-options": {
-        "cxxflags": "-std=c++0x"
-      },
       "sources": [
         {
           "type": "git",
@@ -79,12 +43,9 @@
     },
     {
       "name": "libaio",
-      "config-opts": [
-        "--buildtype=debugoptimized"
-      ],
-      "buildsystem": "simple",
-      "build-commands": [
-        "make prefix=$FLATPAK_DEST install"
+      "no-autogen": true,
+      "make-install-args": [
+          "prefix=${FLATPAK_DEST}"
       ],
       "sources": [
         {
@@ -97,17 +58,24 @@
               "tag-pattern": "^libaio-([\\d.]+)$"
           }
         }
+      ],
+      "cleanup": [
+        "/include",
+        "/lib/*.a"
       ]
     },
     {
       "name": "portaudio",
+      "buildsystem": "cmake-ninja",
+      "config-opts": [
+          "-DCMAKE_BUILD_TYPE=Release"
+      ],
       "cleanup": [
         "/include",
+        "/share/doc",
+        "/lib/cmake",
         "/lib/pkgconfig",
-        "/lib32/*.la"
-      ],
-      "config-opts": [
-        "--disable-static"
+        "/lib/*.a"
       ],
       "sources": [
         {
@@ -124,9 +92,7 @@
     },
     {
       "name": "soundtouch",
-      "config-opts": [
-        "--disable-static"
-      ],
+      "buildsystem": "cmake-ninja",
       "sources": [
         {
           "type": "git",
@@ -142,10 +108,10 @@
       "cleanup": [
         "/bin",
         "/include",
-        "/lib32/pkgconfig",
-        "/share/aclocal",
+        "/lib/cmake",
+        "/lib/pkgconfig",
         "/share/doc",
-        "/lib32/*.la"
+        "/lib/*.a"
       ]
     },
     {
@@ -166,12 +132,7 @@
     },
     {
       "name": "libpcap",
-      "buildsystem": "simple",
-      "build-commands": [
-        "./configure --prefix=/app",
-        "make",
-        "make install"
-      ],
+      "buildsystem": "cmake-ninja",
       "sources": [
         {
           "type": "git",
@@ -183,22 +144,26 @@
               "tag-pattern": "^libpcap-([\\d.]+)$"
           }
         }
+      ],
+      "cleanup": [
+          "/bin",
+          "/include",
+          "/share/man",
+          "/lib/pkgconfig",
+          "/lib/*.a"
       ]
     },
     {
       "name": "pcsx2",
       "buildsystem": "cmake-ninja",
+      "builddir": true,
       "config-opts": [
         "-DCMAKE_BUILD_TYPE=Release",
-        "-DCMAKE_LIBRARY_PATH=/app/lib",
-        "-DPLUGIN_DIR=/app/lib/pcsx2",
-        "-DGTK3_API=TRUE",
         "-DPACKAGE_MODE=TRUE",
         "-DXDG_STD=TRUE",
         "-DDISABLE_BUILD_DATE=TRUE",
         "-DDISABLE_PCSX2_WRAPPER=TRUE",
-        "-DDISABLE_ADVANCE_SIMD=TRUE",
-        "-DOpenGL_GL_PREFERENCE=GLVND"
+        "-DDISABLE_ADVANCE_SIMD=TRUE"
       ],
       "cleanup": [
         "/share/pixmaps",
@@ -207,14 +172,15 @@
       ],
       "post-install": [
         "desktop-file-edit --set-key=Exec --set-value=PCSX2 /app/share/applications/PCSX2.desktop",
-        "install -Dm644 AppIcon128.png /app/share/icons/hicolor/128x128/apps/PCSX2.png",
-        "install -Dm644 net.pcsx2.PCSX2.metainfo.xml /app/share/metainfo/net.pcsx2.PCSX2.metainfo.xml"
+        "install -Dm644 ../AppIcon128.png /app/share/icons/hicolor/128x128/apps/PCSX2.png",
+        "install -Dm644 ../net.pcsx2.PCSX2.metainfo.xml /app/share/metainfo/net.pcsx2.PCSX2.metainfo.xml"
       ],
       "sources": [
         {
           "type": "git",
           "url": "https://github.com/PCSX2/pcsx2.git",
-          "commit": "a35edc95cfef64acc57a1e221f0a62c2e6fcefa2"
+          "disable-shallow-clone": true,
+          "commit": "9abaa1adf684645d4b0a4cbcfc9959031d0cc087"
         },
         {
           "type": "file",

--- a/net.pcsx2.PCSX2.metainfo.xml
+++ b/net.pcsx2.PCSX2.metainfo.xml
@@ -24,7 +24,7 @@
   <url type="homepage">https://pcsx2.net</url>
   <url type="bugtracker">https://github.com/PCSX2/pcsx2/issues</url>
   <releases>
-    <release date="2021-03-19" version="v1.7.0-dev"/>
+    <release date="2021-11-12" version="v1.7.2035"/>
   </releases>
   <screenshots>
     <screenshot type="default">


### PR DESCRIPTION
This PR includes several improvements:
- Update modules and add `x-checker-data` for automatic updating 
- Build with `cmake-ninja` instead of `autotools` when possible
- Remove some remnants of 32-bit configuration: `--allow=multiarch` and `add-extensions` are not needed.
- Update runtime to 21.08