### PR TITLE
Add "automerge-flathubbot-prs"

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,4 @@
 {
+  "automerge-flathubbot-prs": true,
   "only-arches": ["x86_64"]
 }


### PR DESCRIPTION
Prevents to be spammed by PRs now that PCSX2 tags for nearly every commit pushed.

cc @TingPing . Sorry to  "ping" you because you won't get notified otherwise, due to not watching the repo.

Of course other PRs opened by the @flathubbot can be closed afterwards.