### PR TITLE
Add `pcsx2-qt`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,34 +37,32 @@ Since Flatpak does not contain permissions to write to the network stack via lib
 and will need the `--share=network` permissions. (Note: Running apps like this under root is not a good idea.)
 
 If networking still does not work, or adapters do not show up, you will need to grant cap permissions to PCSX2
-```bash
-$> setcap cap_net_raw,cap_net_admin=eip /var/lib/flatpak/app/net.pcsx2.PCSX2/current/active/files/bin/PCSX2
+```sh
+setcap cap_net_raw,cap_net_admin=eip /var/lib/flatpak/app/net.pcsx2.PCSX2/current/active/files/bin/PCSX2
 ```
 
 #### Audio support
 If you run the PCSX2 flatpak under root or some other user, you need to run PulseAudio in multi-user mode to have sound support:
-```bash
-$> flatpak run --system --socket=pulseaudio net.pcsx2.PCSX2`
+```sh
+flatpak run --system --socket=pulseaudio net.pcsx2.PCSX2`
 ```
 
 ### BIOS issues
 PCSX2 tries to open some PS2 BIOS files with lowercase extensions ([PCSX2 issue 5954](/PCSX2/pcsx2/issues/5954)), so rename your PS2's BIOS files to lowercase extensions (`.NVM` -> `.nvm`, etc.)
 
 PCSX2 may write to files in the PS2 BIOS directory. So if in "PCSX2 First Time Configuration" you point to some other directory than the default (the flatpak's data directory), you can grant the flatpak write access to that directory
-```bash
-$> flatpak override --user net.pcsx2.PCSX2 --filesystem=/path/to/my/PS2_BIOS
+```sh
+flatpak override --user net.pcsx2.PCSX2 --filesystem=/path/to/my/PS2_BIOS
 ```
 
-## Building
-If you want to build the PCSX2 flatpak yourself:
+## Build
 
-1. Read the flatpak documentation, starting with [Building your first Flatpak](https://docs.flatpak.org/en/latest/first-build.html).
+`flatpak-builder` is required, see [Building your first Flatpak](https://docs.flatpak.org/en/latest/first-build.html).
 
-2. You need to install the `flatpak-builder` package for your operating system. 
+- Install the SDK
 
-3. Clone this repository, then
+`flatpak install org.kde.Platform/x86_64/6.3 org.kde.Sdk/x86_64/6.3`
 
-```bash
-$> cd net.pcsx2.PCSX2
-$> flatpak-builder builddir --force-clean --install-deps-from=flathub net.pcsx2.PCSX2.json
-```
+- Build PCSX2
+
+`flatpak-builder --user --install --force-clean build-dir net.pcsx2.PCSX2.json`

--- a/net.pcsx2.PCSX2.json
+++ b/net.pcsx2.PCSX2.json
@@ -1,11 +1,9 @@
 {
     "app-id": "net.pcsx2.PCSX2",
-    "runtime": "org.freedesktop.Platform",
-    "sdk": "org.freedesktop.Sdk",
-    "runtime-version": "21.08",
+    "runtime": "org.kde.Platform",
+    "sdk": "org.kde.Sdk",
+    "runtime-version": "6.3",
     "command": "pcsx2",
-    "rename-desktop-file": "PCSX2.desktop",
-    "rename-icon": "PCSX2",
     "finish-args": [
         "--device=all",
         "--share=ipc",
@@ -172,9 +170,11 @@
                 "/share/doc"
             ],
             "post-install": [
-                "desktop-file-edit --set-key=Exec --set-value=pcsx2 /app/share/applications/PCSX2.desktop",
-                "install -Dm644 ../AppIcon128.png /app/share/icons/hicolor/128x128/apps/PCSX2.png",
-                "install -Dm644 ../net.pcsx2.PCSX2.metainfo.xml /app/share/metainfo/net.pcsx2.PCSX2.metainfo.xml"
+                "mv ${FLATPAK_DEST}/share/applications/PCSX2.desktop ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop",
+                "desktop-file-edit --set-key=Exec --set-value=pcsx2 ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop",
+                "desktop-file-edit --set-key=Icon --set-value=net.pcsx2.PCSX2 ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.desktop",
+                "install -Dm644 ../AppIcon128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/net.pcsx2.PCSX2.png",
+                "install -Dm644 ../net.pcsx2.PCSX2.metainfo.xml ${FLATPAK_DEST}/share/metainfo/net.pcsx2.PCSX2.metainfo.xml"
             ],
             "sources": [
                 {
@@ -190,6 +190,41 @@
                 {
                     "type": "file",
                     "path": "AppIcon128.png"
+                }
+            ]
+        },
+        {
+            "name": "pcsx2-qt",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DPACKAGE_MODE=TRUE",
+                "-DXDG_STD=TRUE",
+                "-DDISABLE_BUILD_DATE=TRUE",
+                "-DDISABLE_PCSX2_WRAPPER=TRUE",
+                "-DDISABLE_ADVANCE_SIMD=TRUE",
+                "-DSDL2_API=TRUE",
+                "-DQT_BUILD=TRUE"
+            ],
+            "cleanup": [
+                "/share/pixmaps",
+                "/share/man",
+                "/share/doc"
+            ],
+            "post-install": [
+                "install -Dm644 ${FLATPAK_DEST}/share/applications/PCSX2.desktop ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.Qt.desktop",
+                "desktop-file-edit --set-key=Exec --set-value=pcsx2-qt ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.Qt.desktop",
+                "desktop-file-edit --set-key=Icon --set-value=net.pcsx2.PCSX2 ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.Qt.desktop",
+                "desktop-file-edit --set-key=Name --set-value='PCSX2 Qt' ${FLATPAK_DEST}/share/applications/net.pcsx2.PCSX2.Qt.desktop",
+                "ln -s ${FLATPAK_DEST}/share/PCSX2/resources ${FLATPAK_DEST}/bin/resources"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/PCSX2/pcsx2.git",
+                    "tag": "v1.7.3042",
+                    "commit": "e718a4f8439a8d9e85be1e9f393237a300ecfb1e"
                 }
             ]
         }


### PR DESCRIPTION
The new Qt frontend aims to replace the old wxWidgets one in the future.

It is still WIP and not expected to fully work, that's why it is not the default command.