### PR TITLE
Remove <code> tag in description

### DIFF
--- a/net.pcsx2.PCSX2.metainfo.xml
+++ b/net.pcsx2.PCSX2.metainfo.xml
@@ -20,7 +20,7 @@
       <li>Increase or decrease the game speed by using the built-in frame-limiter</li>
       <li>Ability to record in full HD with the built-in video recorder (F12 using the GSdx plugin)</li>
     </ul>
-    <p>Copy your PS2 BIOS files to the default BIOS search path <code>$HOME/.var/app/net.pcsx2.PCSX2/config/PCSX2/bios</code>.</p>
+    <p>Copy your PS2 BIOS files to the default BIOS search path "$HOME/.var/app/net.pcsx2.PCSX2/config/PCSX2/bios".</p>
   </description>
   <url type="homepage">https://pcsx2.net</url>
   <url type="bugtracker">https://github.com/PCSX2/pcsx2/issues</url>


### PR DESCRIPTION
It is unsupported by some frontends like flathub.org or Discover.

From https://flathub.org/apps/details/net.pcsx2.PCSX2, it looks like this:
```
Copy your PS2 BIOS files to the default BIOS search path<em>$HOME/.var/app/net.pcsx2.PCSX2/config/PCSX2/bios</em><em>.</em>
```