### PR TITLE
Run also FEDC at 01:00 to merge faster and avoid errors

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,7 +1,7 @@
 name: Check for updates
 on:
   schedule: # for scheduling to work this file must be in the default branch
-  - cron: "0 0 * * 0" # Every Sunday at 00:00
+  - cron: "0 0,1 * * 0" # Every Sunday at 00:00 and 01:00
   workflow_dispatch: # can be manually dispatched under GitHub's "Actions" tab
 
 jobs:


### PR DESCRIPTION
Merges any PR created previously by the midnight run.
It is possible that a commit is created between the one hour time span, but it is unlikely.
At any rate it is better than the previous behavior, which will yield to a lint error about the master commit being out-of-date.