### PR TITLE
Qt: Use Qt 6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ flatpak override --user net.pcsx2.PCSX2 --filesystem=/path/to/my/PS2_BIOS
 
 - Install the SDK
 
-`flatpak install org.kde.Platform/x86_64/6.3 org.kde.Sdk/x86_64/6.3`
+`flatpak install org.kde.Platform/x86_64/6.4 org.kde.Sdk/x86_64/6.4`
 
 - Build PCSX2
 
-`flatpak-builder --user --install --force-clean build-dir net.pcsx2.PCSX2.json`
+`flatpak-builder --user --install --force-clean build-dir net.pcsx2.PCSX2.yml`

--- a/net.pcsx2.PCSX2.yml
+++ b/net.pcsx2.PCSX2.yml
@@ -1,7 +1,7 @@
 app-id: net.pcsx2.PCSX2
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: '6.3'
+runtime-version: '6.4'
 command: pcsx2
 finish-args:
   - --device=all


### PR DESCRIPTION
The Qt frontend works just fine with 6.4, also might improve perf as it brings newer mesa (6.4 is based on freedesktop 22.08 vs 21.08).