### PR TITLE
Remove outdated CMake options

### DIFF
--- a/net.pcsx2.PCSX2.metainfo.xml
+++ b/net.pcsx2.PCSX2.metainfo.xml
@@ -25,6 +25,7 @@
   <url type="homepage">https://pcsx2.net</url>
   <url type="bugtracker">https://github.com/PCSX2/pcsx2/issues</url>
   <releases>
+    <release version="1.7.3842" date="2023-01-03"/>
     <release version="1.7.3836" date="2023-01-02"/>
     <release version="1.7.3829" date="2023-01-01"/>
     <release version="1.7.3821" date="2022-12-31"/>

--- a/net.pcsx2.PCSX2.yml
+++ b/net.pcsx2.PCSX2.yml
@@ -74,13 +74,8 @@ modules:
     builddir: true
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DXDG_STD=ON
       - -DDISABLE_BUILD_DATE=ON
-      - -DDISABLE_PCSX2_WRAPPER=ON
       - -DDISABLE_ADVANCE_SIMD=ON
-      - -DSDL2_API=ON
-      - -DWAYLAND_API=ON
-      - -DQT_BUILD=ON
       - -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
     cleanup:
       - /share/pixmaps

--- a/net.pcsx2.PCSX2.yml
+++ b/net.pcsx2.PCSX2.yml
@@ -82,7 +82,7 @@ modules:
       - /share/man
       - /share/doc
     post-install:
-      - cp -r ../bin/* ${FLATPAK_DEST}/bin
+      - cp -r bin/pcsx2-qt ../bin/* ${FLATPAK_DEST}/bin
       - rm ${FLATPAK_DEST}/bin/portable.ini
       - install -Dm644 ../AppIcon128.png ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/net.pcsx2.PCSX2.png
       - install -Dm644 ../net.pcsx2.PCSX2.metainfo.xml ${FLATPAK_DEST}/share/metainfo/net.pcsx2.PCSX2.metainfo.xml

--- a/net.pcsx2.PCSX2.yml
+++ b/net.pcsx2.PCSX2.yml
@@ -96,8 +96,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/PCSX2/pcsx2.git
-        tag: v1.7.3836
-        commit: bed3cae6df7e4a173f2b58bec9fd019139d63f85
+        tag: v1.7.3842
+        commit: 2459145dbf30e681fb04161983bd6e0a3d5f4dd3
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$


### PR DESCRIPTION
Fixes also the build by updating the pcsx2-qt binary source path.