### PR TITLE
Make "pcsx2_patches" tag and commit mismatch not fail building

### DIFF
--- a/net.pcsx2.PCSX2.yml
+++ b/net.pcsx2.PCSX2.yml
@@ -107,7 +107,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/PCSX2/pcsx2_patches.git
-        tag: latest
         commit: d87437a20c552d149635c88a57ce8853ca80d55a
         x-checker-data:
           type: git


### PR DESCRIPTION
this is so if a new version pcsx2_patches is released between flathub updater bot (external data checker) PR and merge, it won't cause failure of build. 