### PR TITLE
Use Clang and make build parameters identical to PCSX2

### DIFF
--- a/net.pcsx2.PCSX2.yml
+++ b/net.pcsx2.PCSX2.yml
@@ -1,8 +1,10 @@
 app-id: net.pcsx2.PCSX2
 runtime: org.kde.Platform
 sdk: org.kde.Sdk
-runtime-version: '6.4'
+runtime-version: '6.5'
 command: pcsx2-qt
+sdk-extensions:
+  - org.freedesktop.Sdk.Extension.llvm16
 finish-args:
   - --device=all
   - --share=network
@@ -74,10 +76,22 @@ modules:
     buildsystem: cmake-ninja
     builddir: true
     config-opts:
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-      - -DDISABLE_BUILD_DATE=ON
-      - -DDISABLE_ADVANCE_SIMD=ON
+      - -DCMAKE_BUILD_TYPE=Release
+      - -DQT_BUILD=ON
+      - -DCUBEB_API=ON
+      - -DX11_API=ON
+      - -DWAYLAND_API=ON
+      - -DENABLE_SETCAP=OFF
+      - -DUSE_SYSTEM_SDL2=ON
+      - -DUSE_SYSTEM_ZSTD=OFF
+      - -DDISABLE_ADVANCE_SIMD=TRUE
+      ##############################################################
       - -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON
+      - -DCMAKE_C_COMPILER=/usr/lib/sdk/llvm16/bin/clang
+      - -DCMAKE_CXX_COMPILER=/usr/lib/sdk/llvm16/bin/clang++
+      - -DCMAKE_EXE_LINKER_FLAGS_INIT=-fuse-ld=/usr/lib/sdk/llvm16/bin/ld.lld
+      - -DCMAKE_MODULE_LINKER_FLAGS_INIT=-fuse-ld=/usr/lib/sdk/llvm16/bin/ld.lld
+      - -DCMAKE_SHARED_LINKER_FLAGS_INIT=-fuse-ld=/usr/lib/sdk/llvm16/bin/ld.lld
     cleanup:
       - /share/pixmaps
       - /share/man


### PR DESCRIPTION
except `USE_SYSTEM_ZSTD=OFF`

This provides a performance boost since `CMAKE_BUILD_TYPE=RelWithDebInfo` prevented inlining which is an optimization technique, also because clang produces slightly faster binaries according to PCSX2 devs.