### PR TITLE
Revert aef5bbd2282210627d31af06f6b80371b14abc8c

### DIFF
--- a/net.pcsx2.PCSX2.yml
+++ b/net.pcsx2.PCSX2.yml
@@ -121,7 +121,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/PCSX2/pcsx2_patches.git
-        commit: d87437a20c552d149635c88a57ce8853ca80d55a
+        tag: latest
+        commit: b9c29a1439a108f16d1114467d01f896c7e138f9
         x-checker-data:
           type: git
           tag-pattern: (latest)


### PR DESCRIPTION
This because the external data checker readds the tag and in the wrong place.
Regression introduced in https://github.com/flathub/net.pcsx2.PCSX2/pull/304
I apologize about that.